### PR TITLE
Request Abort Controllers

### DIFF
--- a/src/Providers/FeedProvider.tsx
+++ b/src/Providers/FeedProvider.tsx
@@ -53,6 +53,8 @@ export const FeedProvider: FC<Props> = ({ filtered, children }: Props) => {
     }
 
     setState(defaultState);
+    const controller = new AbortController();
+    const { signal } = controller;
 
     (async () => {
       const response = await fetch((filtered ? ENDPOINTS.filtered_feed : ENDPOINTS.feed) + user.uuid, {
@@ -60,9 +62,10 @@ export const FeedProvider: FC<Props> = ({ filtered, children }: Props) => {
         headers: {
           Authorization: `Bearer ${token}`,
         },
-      });
+        signal,
+      }).catch(() => null);
 
-      const { status, count, feed } = await response.json();
+      const { status, count, feed } = await response?.json() || {};
       if (status === STATUS_OK) {
         setState({
           status: ProviderStatus.LOADED,
@@ -71,6 +74,8 @@ export const FeedProvider: FC<Props> = ({ filtered, children }: Props) => {
         });
       }
     })();
+
+    return () => controller.abort();
   }, [filtered, token, user?.uuid]);
 
   const value = useMemo(() => ({ ...state, next, prev }), [state]);

--- a/src/Providers/ProfileProvider.tsx
+++ b/src/Providers/ProfileProvider.tsx
@@ -106,7 +106,7 @@ export const ProfileProvider: FC<Props> = ({ uuid, withPosts, withFollowing, chi
         setState({
           status: ProviderStatus.LOADED,
           profile: profile as Profile,
-          posts: (posts as { post: FeedPost}[])?.map(r => r?.post),
+          posts: (posts as { post: FeedPost }[])?.map(r => r?.post),
           following: following as boolean,
         });
       } else {

--- a/src/Providers/SearchProvider.tsx
+++ b/src/Providers/SearchProvider.tsx
@@ -82,6 +82,8 @@ export const SearchProvider: FC<Props> = ({ query, children }: Props) => {
       return;
     }
 
+    const controller = new AbortController();
+    const { signal } = controller;
 
     (async () => {
       const response = await fetch(ENDPOINTS.search, {
@@ -90,9 +92,10 @@ export const SearchProvider: FC<Props> = ({ query, children }: Props) => {
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({ query }),
-      });
+        signal,
+      }).catch(() => null);
 
-      const { status, results } = await response.json();
+      const { status, results } = await response?.json() || {};
       if (status === STATUS_OK) {
         setState((prev) => ({
           ...prev,
@@ -102,6 +105,8 @@ export const SearchProvider: FC<Props> = ({ query, children }: Props) => {
         }));
       }
     })();
+
+    return () => controller.abort();
   }, [token, query]);
 
   const value = useMemo(() => ({ ...state, next, prev }), [state]);


### PR DESCRIPTION
This adds AbortControllers to providers that may rerender during intensive API requests. Fixes #5