### PR TITLE
feat: Add Scroll-to-top button on the feed page

### DIFF
--- a/src/components/ScrollToTop/index.tsx
+++ b/src/components/ScrollToTop/index.tsx
@@ -1,0 +1,34 @@
+import React, { FC, useMemo } from 'react';
+import { KeyboardArrowUp } from '@mui/icons-material';
+import { Grow, Fab, styled, Box } from '@mui/material';
+import useScrollDirection, { ScrollDirection } from '../../hooks/useScrollDirection';
+
+const StyledFabBox = styled(Box)({
+  position: "fixed",
+  bottom: "16px",
+  right: "16px",
+});
+
+export const ScrollToTop: FC = () => {
+  const [direction, { offset, innerHeight }] = useScrollDirection();
+
+  const isVisible: boolean = useMemo(() => (
+    offset > innerHeight && direction === ScrollDirection.Up
+  ), [offset, direction]);
+
+  const onClick = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return (
+    <Grow in={isVisible}>
+      <StyledFabBox>
+        <Fab color="primary" onClick={onClick}>
+          <KeyboardArrowUp />
+        </Fab>
+      </StyledFabBox>
+    </Grow>
+  );
+};
+
+export default ScrollToTop;

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from "react";
+
+export enum ScrollDirection {
+  Up = "up",
+  Down = "down",
+}
+
+/**
+ * A hook that returns the scroll direction of the page.
+ *
+ * @returns [ScrollDirection, { offset: number, innerHeight: number }]
+ */
+const useScrollDirection = (): [ScrollDirection, { offset: number, innerHeight: number }] => {
+  const [lastScrollTop, setLastScrollTop] = useState<number>(0);
+  const [scrollDirection, setScrollDirection] = useState<ScrollDirection>(ScrollDirection.Down);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+      if (scrollTop > lastScrollTop) {
+        setScrollDirection(ScrollDirection.Down);
+      } else {
+        setScrollDirection(ScrollDirection.Up);
+      }
+
+      setLastScrollTop(scrollTop);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [lastScrollTop]);
+
+  return [scrollDirection, { offset: lastScrollTop, innerHeight: window.innerHeight }];
+};
+
+export default useScrollDirection;

--- a/src/pages/feed/View.tsx
+++ b/src/pages/feed/View.tsx
@@ -15,6 +15,7 @@ import TransitionGroup from '../../components/TransitionGroup';
 import TrendingPost from '../../components/TrendingPost';
 import BlogPostCard from '../../components/BlogPost';
 import CreatePost from '../../components/CreatePost';
+import { ScrollToTop } from '../../components/ScrollToTop';
 
 const StyledBox = styled(Box)({
   padding: "16px",
@@ -190,6 +191,7 @@ const Feed : FC = () => {
         {topPost && <TrendingPost reason={topPost.reason} post={topPost.post} />}
         {suggestions?.length > 0 && <SuggestionCard suggestions={suggestions} limit={4} />}
       </StyledSidebarBox>
+      <ScrollToTop />
     </Stack>
   );
 };


### PR DESCRIPTION
- Only appears when scrolling up, and when you're a minimum of 1 viewport height below the top of the page