### PR TITLE
Switching post type clears post photo

### DIFF
--- a/src/components/CreatePost/index.tsx
+++ b/src/components/CreatePost/index.tsx
@@ -123,7 +123,6 @@ const CreatePost: FC<Props> = ({ vehicle }: Props) => {
   const changePostType = (e: React.SyntheticEvent, type: FeedPost["type"]) => {
     setPostType(type);
     setValue("type", type);
-    resetField("image");
   };
 
   const generateDemoPost = (): FeedPost => ({


### PR DESCRIPTION
Fixes #92

The logic already exists to not publish the photo with the post if the post type is not `photo`, all that changed here is that we don't explicitly reset the form field when switching types.