### PR TITLE
Creating two posts from a vehicle page clears the selected vehicle

### DIFF
--- a/src/components/CreatePost/index.tsx
+++ b/src/components/CreatePost/index.tsx
@@ -101,8 +101,8 @@ const CreatePost: FC<Props> = ({ vehicle }: Props) => {
 
   const resetPost = () => {
     setExpand(false);
-    setActiveStep(0);
-    setSelectedVehicle(null);
+    setActiveStep(!vehicle ? 0 : 1);
+    setSelectedVehicle(!vehicle ? null : vehicle);
     setPostType("generic");
     reset();
   };


### PR DESCRIPTION
Fixes #97

This also could be replicated by pressing the "Cancel" button in the Create Post modal.