### PR TITLE
fix: First following user doesn't appear until reload

### DIFF
--- a/src/config/Endpoints.ts
+++ b/src/config/Endpoints.ts
@@ -74,3 +74,6 @@ export const MEDIA_ENDPOINTS = {
 
 export const STATUS_OK = "ok";
 export const STATUS_ERROR = "error";
+export const ERROR_KEY = {
+  NOT_FOLLOWING: "NOT_FOLLOWING",
+};

--- a/src/hooks/useFollowingLookup.ts
+++ b/src/hooks/useFollowingLookup.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useSessionStorage } from "usehooks-ts";
 import { isEqual } from "lodash";
 import { useAuthProvider } from "../Providers/AuthProvider";
-import { ENDPOINTS, STATUS_ERROR, STATUS_OK } from "../config/Endpoints";
+import { ENDPOINTS, ERROR_KEY, STATUS_ERROR, STATUS_OK } from "../config/Endpoints";
 import { CacheKeys } from "../config/Cache";
 
 type Cache = Record<Profile["uuid"], Profile[]>;
@@ -48,12 +48,16 @@ const useFollowingLookup = (uuid: Profile["uuid"], refetch = false): [LookupStat
         return null;
       });
 
-      const { status, following } = await response?.json() || {};
+      const { status, key, following } = await response?.json() || {};
       if (status === STATUS_OK) {
         setCache((prev) => ({ ...prev, [uuid]: following }));
         setStatus(LookupStatus.Success);
         setFollowing(following);
-      } else if (status === STATUS_ERROR) {
+      } else if (status === STATUS_ERROR && key === ERROR_KEY.NOT_FOLLOWING) {
+        setCache((prev) => ({ ...prev, [uuid]: [] }));
+        setStatus(LookupStatus.Success);
+        setFollowing([]);
+      } else {
         setStatus(LookupStatus.Error);
       }
     })();

--- a/src/hooks/useIsFollowingLookup.ts
+++ b/src/hooks/useIsFollowingLookup.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useSessionStorage } from "usehooks-ts";
 import { useAuthProvider } from "../Providers/AuthProvider";
-import { ENDPOINTS, STATUS_ERROR, STATUS_OK } from "../config/Endpoints";
+import { ENDPOINTS, ERROR_KEY, STATUS_ERROR, STATUS_OK } from "../config/Endpoints";
 import { CacheKeys } from "../config/Cache";
 
 type Cache = Record<Profile["uuid"], boolean>;
@@ -65,9 +65,9 @@ const useIsFollowingLookup = (uuid: Profile["uuid"], refetch = false): [{ status
       signal,
     }).catch(() => null);
 
-    const { status: followingLookupStatus, following } = await followingProfiles?.json() || {};
-    if (followingLookupStatus === STATUS_OK) {
-      setFollowingCache((prev) => ({ ...prev, [profile!.uuid]: following }));
+    const { status: followingStatus, key, following } = await followingProfiles?.json() || {};
+    if (followingStatus === STATUS_OK || (followingStatus === STATUS_ERROR && key === ERROR_KEY.NOT_FOLLOWING)) {
+      setFollowingCache((prev) => ({ ...prev, [profile!.uuid]: following || [] }));
     }
 
     return true;


### PR DESCRIPTION
Fixes #106

The REST API returns status of `error` when a user is not following someone. This triggers a false update-skip in the cache state and prevents updating the cache until reloading the page.
