### PR TITLE
fix: Post to a new VIN is rejected

### DIFF
--- a/src/components/Typeahead/VehicleSearch.tsx
+++ b/src/components/Typeahead/VehicleSearch.tsx
@@ -162,7 +162,6 @@ export const VehicleSearch: FC<Props> = ({ value, onChange }: Props) => {
       sx={{ width: 300 }}
       size="small"
       noOptionsText="No vehicles found"
-
     />
   );
 };


### PR DESCRIPTION
Fixes #111

VINwiki blocks creation of a post for a vehicle that doesn't exist. This adds functionality to the typeahead that will fetch the VIN, which forces VINwiki to create the vehicle if it doesn't exist. After fetched, the typeahead will rerender with the new details